### PR TITLE
Uses Fuse.js fuzzy search to filter municipalities

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/query-string": "^4.3.1",
     "@types/react": "^15.0.37",
     "@types/react-dom": "^15.5.1",
+    "fuse.js": "^3.0.5",
     "gh-pages": "^1.0.0",
     "inuitcss": "^6.0.0-beta.5",
     "node-sass-chokidar": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,6 +1771,10 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+fuse.js@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.0.5.tgz#b58d85878802321de94461654947b93af1086727"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
Instead of using naive string search to filter the muncipalities we
can use the fuzzy search library Fuse.js to filter them. This way
incorrect spelling of municipality names won't stop the user from
getting the results she is looking for.

Fuse.js http://fusejs.io/ contains no dependencies and is quite light
weight. This makes it a good library for such a simple site.

The Fuse.js options can be tuned to offer more or less exact matching.

Signed-off-by: Snorre Magnus Davøen <snorremd@gmail.com>